### PR TITLE
Correct issue with %p substitution

### DIFF
--- a/teenymush.pl
+++ b/teenymush.pl
@@ -15335,10 +15335,10 @@ sub evaluate_substitutions
          } else {
            my $sex = get(@{@{$$prog{cmd}}{invoker}}{obj_id},"sex");
 
-           if($sex =~ /(male|boy|garson|gent|father|mr|man|sir|son|brother)/i){
-              $out .= ($seq eq "%p") ? "his" : "His";
-           } elsif($sex =~ /(female|girl|woman|lady|dame|chick|gal|bimbo)/i) {
+           if($sex =~ /(female|girl|woman|lady|dame|chick|gal|bimbo)/i) {
               $out .= ($seq eq "%p") ? "her" : "Her";
+           } elsif($sex =~ /(male|boy|garson|gent|father|mr|man|sir|son|brother)/i) {
+              $out .= ($seq eq "%p") ? "his" : "His";
            } else {
               $out .= ($seq eq "%p") ? "its" : "Its";
            }


### PR DESCRIPTION
The @sex of 'female' and 'woman' does not substitute correctly with %p as 'male' and 'man' match first. So 'female' and 'woman' %p produces 'his'.

Switched evaluation order.