### PR TITLE
Typo in call to or_hasflags() in cmd_motd

### DIFF
--- a/teenymush.pl
+++ b/teenymush.pl
@@ -865,7 +865,7 @@ sub cmd_motd
    verify_switches($self,$prog,$switch,"list") ||
       return;
 
-   !or_hasflag($self,"WIZARD","GOD") &&
+   !or_hasflags($self,"WIZARD","GOD") &&
       return err($self,$prog,"Permission denied.");
 
    if(defined $$switch{list}) {


### PR DESCRIPTION
The call to or_hasflags() in the subroutine cmd_motd is typed as or_hasflag()